### PR TITLE
rm files on mount point, not the original ones

### DIFF
--- a/Tools/installed-to-live
+++ b/Tools/installed-to-live
@@ -608,7 +608,7 @@ bind_mount_template() {
 
             # Don't add broken links
             if test -e $(readlink -f $orig); then
-                RM_FILES="$RM_FILES${RM_FILES:+,}$orig"
+                RM_FILES="$RM_FILES${RM_FILES:+,}$file"
             else
                 pretend rm -f $orig
             fi
@@ -655,7 +655,7 @@ touch_file() {
     test -f $file && return
     test -e $file && fatal "Expected a plain file at $orig"
 
-    RM_FILES="$RM_FILES${RM_FILES:+,}$orig"
+    RM_FILES="$RM_FILES${RM_FILES:+,}$file"
 
     pretend touch $file
 }


### PR DESCRIPTION
I think we need to remove the files on the mount point, not the original files, I'm sure about the second line in touch_file(), could not really test the first one. 