### PR TITLE
fix typo in FULL_DISTRO_NAME token

### DIFF
--- a/LMK-Template/MX/theme.txt
+++ b/LMK-Template/MX/theme.txt
@@ -16,7 +16,7 @@ terminal-box:   "inbox_*.png"
     left  = 30%
     top   = 8%
     width = 100%
-    text  = "Welcome to %FULL_DISTRO_NAME (%CODE_NAME%)!"
+    text  = "Welcome to %FULL_DISTRO_NAME% (%CODE_NAME%)!"
     color = "#ffffff"
     align = "left"
     font  = "DejaVu Sans Regular 18"


### PR DESCRIPTION
just missing a "%" on the end of the token.